### PR TITLE
Pass in loki env.

### DIFF
--- a/addon/adapters/affinity-engine/data-manager-rewindable-lokijs/save.js
+++ b/addon/adapters/affinity-engine/data-manager-rewindable-lokijs/save.js
@@ -4,6 +4,7 @@ import adapter from './adapter';
 export default LokiJSAdapter.extend({
   indices: ['dataGroup', 'isAutosave'],
   lokiOptions: {
-    adapter
+    adapter,
+    env: 'BROWSER'
   }
 });

--- a/addon/adapters/affinity-engine/data-manager-rewindable-lokijs/shared-data.js
+++ b/addon/adapters/affinity-engine/data-manager-rewindable-lokijs/shared-data.js
@@ -4,6 +4,7 @@ import adapter from './adapter';
 export default LokiJSAdapter.extend({
   indices: ['dataGroup'],
   lokiOptions: {
-    adapter
+    adapter,
+    env: 'BROWSER'
   }
 });


### PR DESCRIPTION
This good bug came back:
<img width="513" alt="screen shot 2018-08-05 at 10 19 16 pm" src="https://user-images.githubusercontent.com/541822/43693997-1a73ed20-98ff-11e8-9467-5577f35d26c2.png">
To recreate it clone and run the quickstart.

It looks like it's caused by something new though:
https://github.com/techfort/LokiJS/commit/8f57a7ac5bfcec7a04d28d76f298bff7533062c4#diff-836f9fb20a9413f62a0241007b3b27c1

Here is a pending pull request on Loki that will fix the issue:
https://github.com/techfort/LokiJS/pull/693

In the mean time here is an alternate fix.